### PR TITLE
Add git-hours composite action and workflow

### DIFF
--- a/.github/actions/git-hours/action.yml
+++ b/.github/actions/git-hours/action.yml
@@ -1,0 +1,44 @@
+name: Git Hours
+description: Run git-hours and output JSON report
+inputs:
+  window_start:
+    description: Start date for git-hours, e.g. 2024-01-01
+    required: false
+outputs:
+  results:
+    description: Path to generated git-hours.json
+    value: ${{ steps.output-json.outputs.path }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+    - name: Install git-hours
+      run: |
+        go install github.com/kimmobrunfeldt/git-hours@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Run git-hours
+      run: |
+        if [ -n "${{ inputs.window_start }}" ]; then
+          git-hours --json --since "${{ inputs.window_start }}" > git-hours-raw.json
+        else
+          git-hours --json > git-hours-raw.json
+        fi
+      shell: bash
+    - name: Convert to git-hours.json
+      run: |
+        python <<'PY'
+import json
+with open('git-hours-raw.json') as f:
+    data = json.load(f)
+with open('git-hours.json', 'w') as f:
+    json.dump(data, f, indent=2)
+PY
+      shell: bash
+    - id: output-json
+      run: echo "path=$(pwd)/git-hours.json" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/coding-hours-report.yml
+++ b/.github/workflows/coding-hours-report.yml
@@ -1,0 +1,22 @@
+name: Coding Hours Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      window_start:
+        description: 'Start date for git-hours (YYYY-MM-DD)'
+        required: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/git-hours
+        id: hours
+        with:
+          window_start: ${{ github.event.inputs.window_start }}
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-hours
+          path: ${{ steps.hours.outputs.results }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Coding Hours
+
+This repository contains a reusable GitHub composite action for running the
+[git-hours](https://github.com/kimmobrunfeldt/git-hours) tool.
+
+## Composite Action
+
+The action lives at `.github/actions/git-hours` and performs the following:
+
+1. Checks out your repository.
+2. Installs Go and the `git-hours` tool.
+3. Runs `git-hours` with an optional `window_start` input.
+4. Converts the output to `git-hours.json`.
+5. Exposes the generated file path as the `results` output.
+
+## Example Workflow
+
+Create `.github/workflows/coding-hours-report.yml`:
+
+```yaml
+name: Coding Hours Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      window_start:
+        description: 'Start date for git-hours (YYYY-MM-DD)'
+        required: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/git-hours
+        id: hours
+        with:
+          window_start: ${{ github.event.inputs.window_start }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: git-hours
+          path: ${{ steps.hours.outputs.results }}
+```
+
+Run the workflow manually and the resulting `git-hours.json` file will be
+available as an artifact.


### PR DESCRIPTION
## Summary
- add a reusable git-hours composite action
- report coding hours via a workflow
- document how to use the action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a8d8793508329ba1973b38b57fe9a