### PR TITLE
Add repo list and GitHub Pages

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -1,0 +1,40 @@
+name: Organization Coding Hours
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set
+        run: echo "matrix=$(jq -c '.repos' repos.json)" >> $GITHUB_OUTPUT
+
+  calculate:
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repo }}
+          path: repo
+      - name: Run git-hours
+        uses: .github/actions/git-hours
+        with:
+          window_start: ''
+        working-directory: repo
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.repo }}-git-hours
+          path: repo/git-hours.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Coding Hours
 
-This repository contains a reusable GitHub composite action for running the
-[git-hours](https://github.com/kimmobrunfeldt/git-hours) tool.
+This repository contains a reusable GitHub composite action for running the [git-hours](https://github.com/kimmobrunfeldt/git-hours) tool.
 
 ## Composite Action
 
@@ -41,5 +40,8 @@ jobs:
           path: ${{ steps.hours.outputs.results }}
 ```
 
-Run the workflow manually and the resulting `git-hours.json` file will be
-available as an artifact.
+Run the workflow manually and the resulting `git-hours.json` file will be available as an artifact.
+
+## Organization Reports and GitHub Pages
+
+A separate workflow, `.github/workflows/org-coding-hours.yml`, reads a list of repositories from `repos.json` and generates coding hours reports for each one. The reports can be published or downloaded as artifacts. The repository also serves a GitHub Pages site under the `docs` folder that lists the repositories being tracked.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coding Hours Repositories</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    h1 { color: #333; }
+    ul { list-style-type: none; padding: 0; }
+    li { margin: 0.5em 0; }
+  </style>
+</head>
+<body>
+  <h1>Repositories Tracked for Coding Hours</h1>
+  <ul id="repo-list"></ul>
+  <script>
+    fetch('../repos.json')
+      .then(response => response.json())
+      .then(data => {
+        const list = document.getElementById('repo-list');
+        data.repos.forEach(repo => {
+          const li = document.createElement('li');
+          const link = document.createElement('a');
+          link.href = 'https://github.com/' + repo;
+          link.textContent = repo;
+          li.appendChild(link);
+          list.appendChild(li);
+        });
+      })
+      .catch(err => {
+        document.getElementById('repo-list').textContent = 'Failed to load repo list.';
+        console.error(err);
+      });
+  </script>
+</body>
+</html>

--- a/repos.json
+++ b/repos.json
@@ -1,0 +1,7 @@
+{
+  "repos": [
+    "ni/labview-icon-editor",
+    "ni/actor-framework",
+    "ni/open-source"
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON file listing repos
- create GitHub Pages site that loads repo list
- add workflow to calculate hours across repos
- document new workflow in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688aa343130c83299231b7f60a731e14