### PR TITLE
Add repo path support

### DIFF
--- a/.github/actions/git-hours/action.yml
+++ b/.github/actions/git-hours/action.yml
@@ -4,6 +4,9 @@ inputs:
   window_start:
     description: Start date for git-hours, e.g. 2024-01-01
     required: false
+  repo_path:
+    description: Path to the repository to analyze
+    default: '.'
 outputs:
   results:
     description: Path to generated git-hours.json
@@ -11,7 +14,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
@@ -22,6 +24,7 @@ runs:
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       shell: bash
     - name: Run git-hours
+      working-directory: ${{ inputs.repo_path }}
       run: |
         if [ -n "${{ inputs.window_start }}" ]; then
           git-hours --json --since "${{ inputs.window_start }}" > git-hours-raw.json
@@ -30,6 +33,7 @@ runs:
         fi
       shell: bash
     - name: Convert to git-hours.json
+      working-directory: ${{ inputs.repo_path }}
       run: |
         python <<'PY'
 import json
@@ -40,5 +44,5 @@ with open('git-hours.json', 'w') as f:
 PY
       shell: bash
     - id: output-json
-      run: echo "path=$(pwd)/git-hours.json" >> $GITHUB_OUTPUT
+      run: echo "path=${{ inputs.repo_path }}/git-hours.json" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -1,0 +1,40 @@
+name: Organization Coding Hours
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set
+        run: echo "matrix=$(jq -c '.repos' docs/repos.json)" >> $GITHUB_OUTPUT
+
+  calculate:
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repo }}
+          path: repo
+      - name: Run git-hours
+        uses: ./.github/actions/git-hours
+        with:
+          window_start: ''
+          repo_path: repo
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.repo }}-git-hours
+          path: repo/git-hours.json

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Coding Hours
 
-This repository contains a reusable GitHub composite action for running the
-[git-hours](https://github.com/kimmobrunfeldt/git-hours) tool.
+This repository contains a reusable GitHub composite action for running the [git-hours](https://github.com/kimmobrunfeldt/git-hours) tool.
 
 ## Composite Action
 
 The action lives at `.github/actions/git-hours` and performs the following:
 
-1. Checks out your repository.
-2. Installs Go and the `git-hours` tool.
-3. Runs `git-hours` with an optional `window_start` input.
-4. Converts the output to `git-hours.json`.
-5. Exposes the generated file path as the `results` output.
+1. Installs Go and the `git-hours` tool.
+2. Runs `git-hours` with optional `window_start` and `repo_path` inputs.
+3. Converts the output to `git-hours.json`.
+4. Exposes the generated file path as the `results` output.
 
 ## Example Workflow
 
@@ -35,11 +33,17 @@ jobs:
         id: hours
         with:
           window_start: ${{ github.event.inputs.window_start }}
+          repo_path: '.'
       - uses: actions/upload-artifact@v4
         with:
           name: git-hours
           path: ${{ steps.hours.outputs.results }}
 ```
 
-Run the workflow manually and the resulting `git-hours.json` file will be
-available as an artifact.
+Run the workflow manually and the resulting `git-hours.json` file will be available as an artifact.
+
+## Organization Reports and GitHub Pages
+
+A separate workflow, `.github/workflows/org-coding-hours.yml`, reads a list of repositories from `docs/repos.json` and generates coding hours reports for each one. Each repository is checked out under a `repo` directory and that path is passed to the `repo_path` input of the action. The reports can be published or downloaded as artifacts. The repository also serves a GitHub Pages site under the `docs` folder that lists the repositories being tracked. You can view `docs/index.html` on GitHub Pages to see the current list.
+
+The default `docs/repos.json` file includes open source repositories such as `ni/labview-icon-editor`, `ni/actor-framework`, and `ni/open-source`. You can modify this file to track additional projects. Running the workflow will generate a `git-hours.json` report for each repository, which can be used to recognize the contributions of collaborators.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coding Hours Repositories</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    h1 { color: #333; }
+    ul { list-style-type: none; padding: 0; }
+    li { margin: 0.5em 0; }
+  </style>
+</head>
+<body>
+  <h1>Repositories Tracked for Coding Hours</h1>
+  <ul id="repo-list"></ul>
+  <script>
+    fetch('repos.json')
+      .then(response => response.json())
+      .then(data => {
+        const list = document.getElementById('repo-list');
+        data.repos.forEach(repo => {
+          const li = document.createElement('li');
+          const link = document.createElement('a');
+          link.href = 'https://github.com/' + repo;
+          link.textContent = repo;
+          li.appendChild(link);
+          list.appendChild(li);
+        });
+      })
+      .catch(err => {
+        document.getElementById('repo-list').textContent = 'Failed to load repo list.';
+        console.error(err);
+      });
+  </script>
+</body>
+</html>

--- a/docs/repos.json
+++ b/docs/repos.json
@@ -1,0 +1,7 @@
+{
+  "repos": [
+    "ni/labview-icon-editor",
+    "ni/actor-framework",
+    "ni/open-source"
+  ]
+}


### PR DESCRIPTION
## Summary
- make git-hours action configurable for a repository path
- update org-coding-hours workflow to remove invalid `working-directory` setting
- document `repo_path` input in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688aa343130c83299231b7f60a731e14