### PR TITLE
Update org workflow

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -29,7 +29,8 @@ jobs:
           repository: ${{ matrix.repo }}
           path: repo
       - name: Run git-hours
-        uses: ./.github/actions/git-hours
+        id: hours
+        uses: LabVIEW-Community-CI-CD/coding-hours/.github/actions/git-hours@main
         with:
           window_start: ''
           repo_path: repo
@@ -37,4 +38,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.repo }}-git-hours
-          path: repo/git-hours.json
+          path: ${{ steps.hours.outputs.results }}


### PR DESCRIPTION
## Summary
- switch `org-coding-hours` workflow to use the published `git-hours` action
- capture the output path from the action when uploading the report

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ab0b3aee48329abf11ca1733287d4